### PR TITLE
refactor(application): apply Mapperly to domain-to-dto mappings

### DIFF
--- a/musicxd.api/Directory.Packages.props
+++ b/musicxd.api/Directory.Packages.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/musicxd.api/Directory.Packages.props
+++ b/musicxd.api/Directory.Packages.props
@@ -1,5 +1,2 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-  </PropertyGroup>
 </Project>

--- a/musicxd.api/MusicXD.API/Contracts/SpotifyCatalogDtos.cs
+++ b/musicxd.api/MusicXD.API/Contracts/SpotifyCatalogDtos.cs
@@ -1,0 +1,80 @@
+namespace MusicXD.API.Contracts;
+
+public sealed class SpotifyImageDto
+{
+    public string Url { get; set; } = string.Empty;
+    public int? Height { get; set; }
+    public int? Width { get; set; }
+}
+
+public sealed class SpotifyArtistSummaryDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+}
+
+public sealed class SpotifyAlbumSummaryDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public List<SpotifyImageDto> Images { get; set; } = new();
+}
+
+public sealed class SpotifyArtistDetailsDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public List<string> Genres { get; set; } = new();
+    public List<SpotifyImageDto> Images { get; set; } = new();
+}
+
+public sealed class SpotifyAlbumDetailsDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? ReleaseDate { get; set; }
+    public string? ReleaseDatePrecision { get; set; }
+    public List<SpotifyImageDto> Images { get; set; } = new();
+    public List<SpotifyArtistSummaryDto> Artists { get; set; } = new();
+    public List<string> Genres { get; set; } = new();
+}
+
+public sealed class SpotifyTrackDetailsDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public int DurationMs { get; set; }
+    public int TrackNumber { get; set; }
+    public SpotifyAlbumSummaryDto? Album { get; set; }
+    public List<SpotifyArtistSummaryDto> Artists { get; set; } = new();
+}
+
+public sealed class SpotifyArtistDto
+{
+    public SpotifyArtistDetailsDto Artist { get; set; } = new();
+}
+
+public sealed class SpotifyAlbumDto
+{
+    public SpotifyAlbumDetailsDto Album { get; set; } = new();
+}
+
+public sealed class SpotifyTrackDto
+{
+    public SpotifyTrackDetailsDto Track { get; set; } = new();
+}
+
+public sealed class SpotifyArtistSearchResultDto
+{
+    public List<SpotifyArtistDetailsDto> Result { get; set; } = new();
+}
+
+public sealed class SpotifyAlbumSearchResultDto
+{
+    public List<SpotifyAlbumDetailsDto> Result { get; set; } = new();
+}
+
+public sealed class SpotifyTrackSearchResultDto
+{
+    public List<SpotifyTrackDetailsDto> Result { get; set; } = new();
+}

--- a/musicxd.api/MusicXD.API/Controllers/SpotifyCatalogController.cs
+++ b/musicxd.api/MusicXD.API/Controllers/SpotifyCatalogController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using MusicXD.API.Mapper;
 using MusicXD.Infrastructure.ExternalServices.Spotify.SpotifyClient;
 
 namespace MusicXD.API.Controllers;
@@ -11,14 +12,6 @@ public class SpotifyCatalogController : ControllerBase
 {
     private readonly ISpotifyClient _spotifyClient;
 
-    // DTOs used to avoid exposing Infrastructure/Spotify models directly
-    public sealed record SpotifyArtistDto(object Artist);
-    public sealed record SpotifyAlbumDto(object Album);
-    public sealed record SpotifyTrackDto(object Track);
-    public sealed record SpotifyArtistSearchResultDto(object Result);
-    public sealed record SpotifyAlbumSearchResultDto(object Result);
-    public sealed record SpotifyTrackSearchResultDto(object Result);
-
     public SpotifyCatalogController(ISpotifyClient spotifyClient)
     {
         _spotifyClient = spotifyClient;
@@ -28,41 +21,41 @@ public class SpotifyCatalogController : ControllerBase
     public async Task<IActionResult> GetArtist(string id, CancellationToken cancellationToken)
     {
         var artist = await _spotifyClient.GetArtistAsync(id, cancellationToken);
-        return Ok(new SpotifyArtistDto(artist));
+        return Ok(artist.ToSpotifyArtistDto());
     }
 
     [HttpGet("albums/{id}")]
     public async Task<IActionResult> GetAlbum(string id, [FromQuery] string? market, CancellationToken cancellationToken)
     {
         var album = await _spotifyClient.GetAlbumAsync(id, market, cancellationToken);
-        return Ok(new SpotifyAlbumDto(album));
+        return Ok(album.ToSpotifyAlbumDto());
     }
 
     [HttpGet("tracks/{id}")]
     public async Task<IActionResult> GetTrack(string id, [FromQuery] string? market, CancellationToken cancellationToken)
     {
         var track = await _spotifyClient.GetTrackAsync(id, market, cancellationToken);
-        return Ok(new SpotifyTrackDto(track));
+        return Ok(track.ToSpotifyTrackDto());
     }
 
     [HttpGet("search/artists")]
     public async Task<IActionResult> SearchArtists([FromQuery(Name = "q")] string query, [FromQuery] int limit = 10, [FromQuery] string? market = null, CancellationToken cancellationToken = default)
     {
         var artists = await _spotifyClient.SearchArtistsAsync(query, limit, market, cancellationToken);
-        return Ok(new SpotifyArtistSearchResultDto(artists));
+        return Ok(artists.ToSpotifyArtistSearchResultDto());
     }
 
     [HttpGet("search/albums")]
     public async Task<IActionResult> SearchAlbums([FromQuery(Name = "q")] string query, [FromQuery] int limit = 10, [FromQuery] string? market = null, CancellationToken cancellationToken = default)
     {
         var albums = await _spotifyClient.SearchAlbumsAsync(query, limit, market, cancellationToken);
-        return Ok(new SpotifyAlbumSearchResultDto(albums));
+        return Ok(albums.ToSpotifyAlbumSearchResultDto());
     }
 
     [HttpGet("search/tracks")]
     public async Task<IActionResult> SearchTracks([FromQuery(Name = "q")] string query, [FromQuery] int limit = 10, [FromQuery] string? market = null, CancellationToken cancellationToken = default)
     {
         var tracks = await _spotifyClient.SearchTracksAsync(query, limit, market, cancellationToken);
-        return Ok(new SpotifyTrackSearchResultDto(tracks));
+        return Ok(tracks.ToSpotifyTrackSearchResultDto());
     }
 }

--- a/musicxd.api/MusicXD.API/Mapper/SpotifyCatalogMapper.cs
+++ b/musicxd.api/MusicXD.API/Mapper/SpotifyCatalogMapper.cs
@@ -1,0 +1,57 @@
+using MusicXD.API.Contracts;
+using MusicXD.Infrastructure.ExternalServices.Spotify.SpotifyModels;
+using Riok.Mapperly.Abstractions;
+
+namespace MusicXD.API.Mapper;
+
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public static partial class SpotifyCatalogMapper
+{
+    public static partial SpotifyImageDto ToSpotifyImageDto(this SpotifyImage image);
+
+    public static partial SpotifyArtistSummaryDto ToSpotifyArtistSummaryDto(this SpotifyArtistSummary artist);
+
+    public static partial SpotifyAlbumSummaryDto ToSpotifyAlbumSummaryDto(this SpotifyAlbumSummary album);
+
+    public static partial SpotifyArtistDetailsDto ToSpotifyArtistDetailsDto(this SpotifyArtistResponse artist);
+
+    public static partial SpotifyAlbumDetailsDto ToSpotifyAlbumDetailsDto(this SpotifyAlbumResponse album);
+
+    public static partial SpotifyTrackDetailsDto ToSpotifyTrackDetailsDto(this SpotifyTrackResponse track);
+
+    public static partial List<SpotifyArtistDetailsDto> ToSpotifyArtistDetailsDtos(this IReadOnlyList<SpotifyArtistResponse> artists);
+
+    public static partial List<SpotifyAlbumDetailsDto> ToSpotifyAlbumDetailsDtos(this IReadOnlyList<SpotifyAlbumResponse> albums);
+
+    public static partial List<SpotifyTrackDetailsDto> ToSpotifyTrackDetailsDtos(this IReadOnlyList<SpotifyTrackResponse> tracks);
+
+    public static SpotifyArtistDto ToSpotifyArtistDto(this SpotifyArtistResponse artist) => new()
+    {
+        Artist = artist.ToSpotifyArtistDetailsDto()
+    };
+
+    public static SpotifyAlbumDto ToSpotifyAlbumDto(this SpotifyAlbumResponse album) => new()
+    {
+        Album = album.ToSpotifyAlbumDetailsDto()
+    };
+
+    public static SpotifyTrackDto ToSpotifyTrackDto(this SpotifyTrackResponse track) => new()
+    {
+        Track = track.ToSpotifyTrackDetailsDto()
+    };
+
+    public static SpotifyArtistSearchResultDto ToSpotifyArtistSearchResultDto(this IReadOnlyList<SpotifyArtistResponse> artists) => new()
+    {
+        Result = artists.ToSpotifyArtistDetailsDtos()
+    };
+
+    public static SpotifyAlbumSearchResultDto ToSpotifyAlbumSearchResultDto(this IReadOnlyList<SpotifyAlbumResponse> albums) => new()
+    {
+        Result = albums.ToSpotifyAlbumDetailsDtos()
+    };
+
+    public static SpotifyTrackSearchResultDto ToSpotifyTrackSearchResultDto(this IReadOnlyList<SpotifyTrackResponse> tracks) => new()
+    {
+        Result = tracks.ToSpotifyTrackDetailsDtos()
+    };
+}

--- a/musicxd.api/MusicXD.API/MusicXD.API.csproj
+++ b/musicxd.api/MusicXD.API/MusicXD.API.csproj
@@ -10,6 +10,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Riok.Mapperly" Version="4.3.1" PrivateAssets="all" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
 

--- a/musicxd.api/MusicXD.Application/Features/ActivityFeed/Queries/GetActivityFeedQuery.cs
+++ b/musicxd.api/MusicXD.Application/Features/ActivityFeed/Queries/GetActivityFeedQuery.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using MusicXD.Application.DTOs;
 using MusicXD.Application.Interfaces;
+using MusicXD.Application.Mapper;
 
 namespace MusicXD.Application.Features.ActivityFeed.Queries;
 
@@ -24,13 +25,6 @@ public class GetActivityFeedQueryHandler : IRequestHandler<GetActivityFeedQuery,
             .OrderByDescending(a => a.CreatedAt)
             .ToListAsync(cancellationToken);
 
-        return activities.Select(activity => new ActivityFeedDto
-        {
-            Id = activity.Id,
-            UserId = activity.UserId,
-            EventType = activity.Type.ToString(),
-            Payload = activity.Payload,
-            CreatedAt = activity.CreatedAt
-        });
+        return activities.Select(activity => activity.ToActivityFeedDto());
     }
 }

--- a/musicxd.api/MusicXD.Application/Features/AlbumReviews/Commands/CreateAlbumReviewCommand.cs
+++ b/musicxd.api/MusicXD.Application/Features/AlbumReviews/Commands/CreateAlbumReviewCommand.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using MusicXD.Application.DTOs;
 using MusicXD.Application.Interfaces;
+using MusicXD.Application.Mapper;
 using MusicXD.Domain.Entities;
 using MusicXD.Domain.Enums;
 using MusicXD.Domain.ValueObjects;
@@ -41,14 +42,6 @@ public class CreateAlbumReviewCommandHandler : IRequestHandler<CreateAlbumReview
             review.Id.ToString()));
         await _context.SaveChangesAsync(cancellationToken);
 
-        return new AlbumReviewDto
-        {
-            Id = review.Id,
-            UserId = review.UserId,
-            AlbumId = review.AlbumId,
-            Rating = review.Rating.Value,
-            Content = review.ReviewText.Value,
-            CreatedAt = review.CreatedAt
-        };
+        return review.ToAlbumReviewDto();
     }
 }

--- a/musicxd.api/MusicXD.Application/Features/AlbumReviews/Queries/GetAlbumReviewsQuery.cs
+++ b/musicxd.api/MusicXD.Application/Features/AlbumReviews/Queries/GetAlbumReviewsQuery.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using MusicXD.Application.DTOs;
 using MusicXD.Application.Interfaces;
+using MusicXD.Application.Mapper;
 
 namespace MusicXD.Application.Features.AlbumReviews.Queries;
 
@@ -25,15 +26,6 @@ public class GetAlbumReviewsQueryHandler : IRequestHandler<GetAlbumReviewsQuery,
             select new { review, user })
             .ToListAsync(cancellationToken);
 
-        return reviews.Select(result => new AlbumReviewDto
-        {
-            Id = result.review.Id,
-            UserId = result.review.UserId,
-            Username = result.user.Username.Value,
-            AlbumId = result.review.AlbumId,
-            Rating = result.review.Rating.Value,
-            Content = result.review.ReviewText.Value,
-            CreatedAt = result.review.CreatedAt
-        });
+        return reviews.Select(result => result.review.ToAlbumReviewDto(result.user.Username.Value));
     }
 }

--- a/musicxd.api/MusicXD.Application/Features/Auth/Commands/RegisterUserCommand.cs
+++ b/musicxd.api/MusicXD.Application/Features/Auth/Commands/RegisterUserCommand.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using MusicXD.Application.DTOs;
 using MusicXD.Application.Interfaces;
+using MusicXD.Application.Mapper;
 using MusicXD.Domain.Entities;
 using MusicXD.Domain.ValueObjects;
 
@@ -47,12 +48,6 @@ public class RegisterUserCommandHandler : IRequestHandler<RegisterUserCommand, U
         _context.Users.Add(user);
         await _context.SaveChangesAsync(cancellationToken);
 
-        return new UserDto
-        {
-            Id = user.Id,
-            Username = user.Username.Value,
-            Email = user.Email.Value,
-            CreatedAt = user.CreatedAt
-        };
+        return user.ToUserDto();
     }
 }

--- a/musicxd.api/MusicXD.Application/Features/TrackReviews/Commands/CreateTrackReviewCommand.cs
+++ b/musicxd.api/MusicXD.Application/Features/TrackReviews/Commands/CreateTrackReviewCommand.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using MusicXD.Application.DTOs;
 using MusicXD.Application.Interfaces;
+using MusicXD.Application.Mapper;
 using MusicXD.Domain.Entities;
 using MusicXD.Domain.Enums;
 using MusicXD.Domain.ValueObjects;
@@ -41,13 +42,6 @@ public class CreateTrackRatingCommandHandler : IRequestHandler<CreateTrackRating
             rating.Id.ToString()));
         await _context.SaveChangesAsync(cancellationToken);
 
-        return new TrackRatingDto
-        {
-            Id = rating.Id,
-            UserId = rating.UserId,
-            TrackId = rating.TrackId,
-            Rating = rating.Rating.Value,
-            CreatedAt = rating.CreatedAt
-        };
+        return rating.ToTrackRatingDto();
     }
 }

--- a/musicxd.api/MusicXD.Application/Features/TrackReviews/Queries/GetTrackReviewsQuery.cs
+++ b/musicxd.api/MusicXD.Application/Features/TrackReviews/Queries/GetTrackReviewsQuery.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using MusicXD.Application.DTOs;
 using MusicXD.Application.Interfaces;
+using MusicXD.Application.Mapper;
 
 namespace MusicXD.Application.Features.TrackRatings.Queries;
 
@@ -25,14 +26,6 @@ public class GetTrackRatingsQueryHandler : IRequestHandler<GetTrackRatingsQuery,
             select new { rating, user })
             .ToListAsync(cancellationToken);
 
-        return ratings.Select(result => new TrackRatingDto
-        {
-            Id = result.rating.Id,
-            UserId = result.rating.UserId,
-            Username = result.user.Username.Value,
-            TrackId = result.rating.TrackId,
-            Rating = result.rating.Rating.Value,
-            CreatedAt = result.rating.CreatedAt
-        });
+        return ratings.Select(result => result.rating.ToTrackRatingDto(result.user.Username.Value));
     }
 }

--- a/musicxd.api/MusicXD.Application/Features/Users/Queries/GetUserProfileQuery.cs
+++ b/musicxd.api/MusicXD.Application/Features/Users/Queries/GetUserProfileQuery.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using MusicXD.Application.DTOs;
 using MusicXD.Application.Interfaces;
+using MusicXD.Application.Mapper;
 
 namespace MusicXD.Application.Features.Users.Queries;
 
@@ -19,17 +20,10 @@ public class GetUserProfileQueryHandler : IRequestHandler<GetUserProfileQuery, U
     public async Task<UserDto> Handle(GetUserProfileQuery request, CancellationToken cancellationToken)
     {
         var user = await _context.Users
+            .AsNoTracking()
             .FirstOrDefaultAsync(u => u.Id == request.UserId, cancellationToken)
             ?? throw new KeyNotFoundException($"User {request.UserId} not found.");
 
-        return new UserDto
-        {
-            Id = user.Id,
-            Username = user.Username.Value,
-            Email = user.Email.Value,
-            Bio = user.Bio,
-            ProfileImageUrl = user.ProfileImageUrl,
-            CreatedAt = user.CreatedAt
-        };
+        return user.ToUserDto();
     }
 }

--- a/musicxd.api/MusicXD.Application/Mapper/ActivityMapper.cs
+++ b/musicxd.api/MusicXD.Application/Mapper/ActivityMapper.cs
@@ -1,0 +1,15 @@
+using MusicXD.Application.DTOs;
+using MusicXD.Domain.Entities;
+using MusicXD.Domain.Enums;
+using Riok.Mapperly.Abstractions;
+
+namespace MusicXD.Application.Mapper;
+
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public static partial class ActivityMapper
+{
+    [MapProperty(nameof(Activity.Type), nameof(ActivityFeedDto.EventType))]
+    public static partial ActivityFeedDto ToActivityFeedDto(this Activity activity);
+
+    private static string Map(ActivityType type) => type.ToString();
+}

--- a/musicxd.api/MusicXD.Application/Mapper/AlbumMapper.cs
+++ b/musicxd.api/MusicXD.Application/Mapper/AlbumMapper.cs
@@ -1,0 +1,17 @@
+using MusicXD.Application.DTOs;
+using MusicXD.Domain.Entities;
+using MusicXD.Domain.ValueObjects;
+using Riok.Mapperly.Abstractions;
+
+namespace MusicXD.Application.Mapper;
+
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public static partial class AlbumMapper
+{
+    [MapperIgnoreTarget(nameof(AlbumDto.ArtistName))]
+    public static partial AlbumDto ToAlbumDto(this Album album);
+
+    public static partial AlbumDto ToAlbumDto(this Album album, string artistName);
+
+    private static string Map(SpotifyId spotifyId) => spotifyId.Value;
+}

--- a/musicxd.api/MusicXD.Application/Mapper/AlbumReviewMapper.cs
+++ b/musicxd.api/MusicXD.Application/Mapper/AlbumReviewMapper.cs
@@ -1,0 +1,21 @@
+using MusicXD.Application.DTOs;
+using MusicXD.Domain.Entities;
+using MusicXD.Domain.ValueObjects;
+using Riok.Mapperly.Abstractions;
+
+namespace MusicXD.Application.Mapper;
+
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public static partial class AlbumReviewMapper
+{
+    [MapperIgnoreTarget(nameof(AlbumReviewDto.Username))]
+    [MapProperty(nameof(AlbumReview.ReviewText), nameof(AlbumReviewDto.Content))]
+    public static partial AlbumReviewDto ToAlbumReviewDto(this AlbumReview review);
+
+    [MapProperty(nameof(AlbumReview.ReviewText), nameof(AlbumReviewDto.Content))]
+    public static partial AlbumReviewDto ToAlbumReviewDto(this AlbumReview review, string username);
+
+    private static decimal Map(Rating rating) => rating.Value;
+
+    private static string Map(ReviewText reviewText) => reviewText.Value;
+}

--- a/musicxd.api/MusicXD.Application/Mapper/ArtistMapper.cs
+++ b/musicxd.api/MusicXD.Application/Mapper/ArtistMapper.cs
@@ -1,0 +1,14 @@
+using MusicXD.Application.DTOs;
+using MusicXD.Domain.Entities;
+using MusicXD.Domain.ValueObjects;
+using Riok.Mapperly.Abstractions;
+
+namespace MusicXD.Application.Mapper;
+
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public static partial class ArtistMapper
+{
+    public static partial ArtistDto ToArtistDto(this Artist artist);
+
+    private static string Map(SpotifyId spotifyId) => spotifyId.Value;
+}

--- a/musicxd.api/MusicXD.Application/Mapper/TrackMapper.cs
+++ b/musicxd.api/MusicXD.Application/Mapper/TrackMapper.cs
@@ -1,0 +1,17 @@
+using MusicXD.Application.DTOs;
+using MusicXD.Domain.Entities;
+using MusicXD.Domain.ValueObjects;
+using Riok.Mapperly.Abstractions;
+
+namespace MusicXD.Application.Mapper;
+
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public static partial class TrackMapper
+{
+    [MapperIgnoreTarget(nameof(TrackDto.AlbumTitle))]
+    public static partial TrackDto ToTrackDto(this Track track);
+
+    public static partial TrackDto ToTrackDto(this Track track, string albumTitle);
+
+    private static string Map(SpotifyId spotifyId) => spotifyId.Value;
+}

--- a/musicxd.api/MusicXD.Application/Mapper/TrackRatingMapper.cs
+++ b/musicxd.api/MusicXD.Application/Mapper/TrackRatingMapper.cs
@@ -1,0 +1,17 @@
+using MusicXD.Application.DTOs;
+using MusicXD.Domain.Entities;
+using MusicXD.Domain.ValueObjects;
+using Riok.Mapperly.Abstractions;
+
+namespace MusicXD.Application.Mapper;
+
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public static partial class TrackRatingMapper
+{
+    [MapperIgnoreTarget(nameof(TrackRatingDto.Username))]
+    public static partial TrackRatingDto ToTrackRatingDto(this TrackRating rating);
+
+    public static partial TrackRatingDto ToTrackRatingDto(this TrackRating rating, string username);
+
+    private static decimal Map(Rating rating) => rating.Value;
+}

--- a/musicxd.api/MusicXD.Application/Mapper/UserMapper.cs
+++ b/musicxd.api/MusicXD.Application/Mapper/UserMapper.cs
@@ -1,0 +1,16 @@
+using MusicXD.Application.DTOs;
+using MusicXD.Domain.Entities;
+using MusicXD.Domain.ValueObjects;
+using Riok.Mapperly.Abstractions;
+
+namespace MusicXD.Application.Mapper;
+
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public static partial class UserMapper
+{
+    public static partial UserDto ToUserDto(this User user);
+
+    private static string Map(Username username) => username.Value;
+
+    private static string Map(Email email) => email.Value;
+}

--- a/musicxd.api/MusicXD.Application/MusicXD.Application.csproj
+++ b/musicxd.api/MusicXD.Application/MusicXD.Application.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageReference Include="MediatR" Version="14.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.14" />
+    <PackageReference Include="Riok.Mapperly" Version="4.3.1" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/musicxd.api/MusicXD.Infrastructure/ExternalServices/Spotify/SpotifyMapper/SpotifyMapper.cs
+++ b/musicxd.api/MusicXD.Infrastructure/ExternalServices/Spotify/SpotifyMapper/SpotifyMapper.cs
@@ -1,69 +1,59 @@
 using System.Globalization;
 using MusicXD.Application.DTOs;
 using MusicXD.Infrastructure.ExternalServices.Spotify.SpotifyModels;
+using Riok.Mapperly.Abstractions;
 
 namespace MusicXD.Infrastructure.ExternalServices.Spotify.SpotifyMapper;
 
-public static class SpotifyMapper
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public static partial class SpotifyMapper
 {
-    public static ArtistDto ToArtistDto(this SpotifyArtistResponse artist) => new()
-    {
-        Id = Guid.Empty,
-        SpotifyId = artist.Id,
-        Name = artist.Name,
-        ImageUrl = artist.Images.FirstOrDefault()?.Url,
-        Genres = artist.Genres
-    };
+    [MapperIgnoreTarget(nameof(ArtistDto.Id))]
+    [MapProperty(nameof(SpotifyArtistResponse.Id), nameof(ArtistDto.SpotifyId))]
+    [MapProperty(nameof(SpotifyArtistResponse.Images), nameof(ArtistDto.ImageUrl))]
+    public static partial ArtistDto ToArtistDto(this SpotifyArtistResponse artist);
 
-    public static AlbumDto ToAlbumDto(this SpotifyAlbumResponse album)
-    {
-        var primaryArtist = album.Artists.FirstOrDefault();
+    [MapperIgnoreTarget(nameof(AlbumDto.Id))]
+    [MapperIgnoreTarget(nameof(AlbumDto.ArtistId))]
+    [MapProperty(nameof(SpotifyAlbumResponse.Id), nameof(AlbumDto.SpotifyId))]
+    [MapProperty(nameof(SpotifyAlbumResponse.Name), nameof(AlbumDto.Title))]
+    [MapProperty(nameof(SpotifyAlbumResponse.ReleaseDate), nameof(AlbumDto.ReleaseDate))]
+    [MapProperty(nameof(SpotifyAlbumResponse.Images), nameof(AlbumDto.CoverImageUrl))]
+    [MapProperty(nameof(SpotifyAlbumResponse.Artists), nameof(AlbumDto.ArtistName))]
+    public static partial AlbumDto ToAlbumDto(this SpotifyAlbumResponse album);
 
-        return new AlbumDto
-        {
-            Id = Guid.Empty,
-            SpotifyId = album.Id,
-            Title = album.Name,
-            ArtistId = Guid.Empty,
-            ArtistName = primaryArtist?.Name ?? string.Empty,
-            ReleaseDate = ParseReleaseDate(album.ReleaseDate, album.ReleaseDatePrecision),
-            CoverImageUrl = album.Images.FirstOrDefault()?.Url,
-            Genres = album.Genres
-        };
-    }
+    [MapperIgnoreTarget(nameof(TrackDto.Id))]
+    [MapperIgnoreTarget(nameof(TrackDto.AlbumId))]
+    [MapProperty(nameof(SpotifyTrackResponse.Id), nameof(TrackDto.SpotifyId))]
+    [MapProperty(nameof(SpotifyTrackResponse.Name), nameof(TrackDto.Title))]
+    [MapProperty(nameof(SpotifyTrackResponse.Album), nameof(TrackDto.AlbumTitle))]
+    public static partial TrackDto ToTrackDto(this SpotifyTrackResponse track);
 
-    public static TrackDto ToTrackDto(this SpotifyTrackResponse track) => new()
-    {
-        Id = Guid.Empty,
-        SpotifyId = track.Id,
-        Title = track.Name,
-        AlbumId = Guid.Empty,
-        AlbumTitle = track.Album?.Name ?? string.Empty,
-        DurationMs = track.DurationMs,
-        TrackNumber = track.TrackNumber
-    };
+    private static string? Map(List<SpotifyImage> images) => images.FirstOrDefault()?.Url;
 
-    private static DateTime ParseReleaseDate(string? releaseDate, string? precision)
+    private static string Map(List<SpotifyArtistSummary> artists) => artists.FirstOrDefault()?.Name ?? string.Empty;
+
+    private static string Map(SpotifyAlbumSummary? album) => album?.Name ?? string.Empty;
+
+    private static DateTime Map(string? releaseDate)
     {
         if (string.IsNullOrWhiteSpace(releaseDate))
         {
             return DateTime.MinValue;
         }
 
-        var formats = precision switch
-        {
-            "year" => new[] { "yyyy" },
-            "month" => new[] { "yyyy-MM" },
-            _ => new[] { "yyyy-MM-dd", "yyyy-MM", "yyyy" }
-        };
-
-        return DateTime.TryParseExact(
-            releaseDate,
-            formats,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-            out var parsedDate)
+        return TryParseReleaseDate(releaseDate, out var parsedDate)
             ? parsedDate
             : DateTime.MinValue;
+    }
+
+    private static bool TryParseReleaseDate(string releaseDate, out DateTime parsedDate)
+    {
+        return DateTime.TryParseExact(
+            releaseDate,
+            new[] { "yyyy-MM-dd", "yyyy-MM", "yyyy" },
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out parsedDate);
     }
 }

--- a/musicxd.api/MusicXD.Infrastructure/MusicXD.Infrastructure.csproj
+++ b/musicxd.api/MusicXD.Infrastructure/MusicXD.Infrastructure.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <PackageReference Include="Riok.Mapperly" Version="4.3.1" PrivateAssets="all" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.24" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.3.1" />
   </ItemGroup>


### PR DESCRIPTION
Fiz a adoção do Mapperly em três frentes: mapeamentos de domínio na Application, mapeamentos do fluxo de Spotify na Infrastructure, e mapeamentos dos contratos HTTP do catálogo Spotify na API.

Base do projeto

Adicionei [Directory.Packages.props](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) para o repositório parar de herdar o Central Package Management da sua pasta de usuário, que estava quebrando o restore.
Adicionei Riok.Mapperly em [MusicXD.Application.csproj](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/), [MusicXD.Infrastructure.csproj](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) e [MusicXD.API.csproj](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/).
Application

Criei [UserMapper.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) para User -> UserDto, com conversão dos value objects Username e Email.
Criei [ActivityMapper.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) para Activity -> ActivityFeedDto, convertendo ActivityType para string.
Criei [ArtistMapper.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) para Artist -> ArtistDto.
Criei [AlbumMapper.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) para Album -> AlbumDto, incluindo overload com artistName porque AlbumDto tem campo enriquecido.
Criei [TrackMapper.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) para Track -> TrackDto, incluindo overload com albumTitle.
Criei [AlbumReviewMapper.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) para AlbumReview -> AlbumReviewDto, mapeando ReviewText -> Content e Rating -> decimal, com overload para username.
Criei [TrackRatingMapper.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) para TrackRating -> TrackRatingDto, com overload para username.
Substituí new UserDto { ... } por mapper em [RegisterUserCommand.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) e [GetUserProfileQuery.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/).
Substituí new AlbumReviewDto { ... } por mapper em [CreateAlbumReviewCommand.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) e [GetAlbumReviewsQuery.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/).
Substituí new TrackRatingDto { ... } por mapper em [CreateTrackReviewCommand.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) e [GetTrackReviewsQuery.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/).
Substituí new ActivityFeedDto { ... } por mapper em [GetActivityFeedQuery.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/).
Adicionei AsNoTracking() em [GetUserProfileQuery.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) porque é consulta read-only.
Spotify / Infrastructure

Convertei [SpotifyMapper.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) de mapper manual para Mapperly.
Mantive conversões customizadas necessárias nesse mapper: images -> ImageUrl/CoverImageUrl, artists -> ArtistName, album -> AlbumTitle e parse de releaseDate -> DateTime.
O objetivo ali ficou: SpotifyArtistResponse -> ArtistDto, SpotifyAlbumResponse -> AlbumDto e SpotifyTrackResponse -> TrackDto.
Spotify / API

Criei DTOs tipados para o catálogo em [SpotifyCatalogDtos.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) no lugar dos wrappers com object.
Criei [SpotifyCatalogMapper.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) para mapear SpotifyImage, SpotifyArtistSummary, SpotifyAlbumSummary, SpotifyArtistResponse, SpotifyAlbumResponse, SpotifyTrackResponse e listas de busca para os DTOs da API.
Atualizei [SpotifyCatalogController.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) para usar os métodos do mapper em vez de new SpotifyArtistDto(artist) e equivalentes.
Observações

Não mexi no [Program.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/), porque os mappers foram feitos como static partial class; nesse modelo não existe registro em DI.
Follow ficou sem mapper porque não existe FollowDto na Application e o caso de uso atual retorna Unit, não DTO.
[SpotifyService.cs](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Luis%20Felipe/.vscode/extensions/openai.chatgpt-26.313.41514-win32-x64/webview/) ainda mantém mapeamento manual próprio para top tracks/top artists; isso não foi migrado ainda.
Validação

Rodei dotnet build musicxd.api/MusicXD.API/MusicXD.API.cspro